### PR TITLE
fix: skipping non-semantic commit from template

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ci:commitlint": "commitlint-jenkins --pr-only",
     "lint": "eslint . && tsc -p tsconfig-lint.json",
     "prepublishOnly": "npm run build && if [ \"$CI\" = '' ] && [ \"$npm_config_dry_run\" != true ]; then node -p 'JSON.parse(process.env.npm_package_config_manualPublishMessage)'; exit 1; fi",
-    "semantic-release": "semantic-release",
+    "semantic-release": "SEMANTIC_COMMITLINT_SKIP=1ee4858 semantic-release",
     "test": "jest"
   },
   "repository": {


### PR DESCRIPTION
#### Changes Made
Skipping non-semantic initial commit from gh template https://github.com/mixmaxhq/salesforce-ip-addresses/commit/1ee4858c6a44fc933107ca38aa250da638df785a so CI can pass...

cc — https://github.com/mixmaxhq/salesforce-ip-addresses/issues/3

#### Potential Risks
low

#### Test Plan
- [x] Ensure CI is passing and we are exporting correctly as default and named export