### PR TITLE
chore: remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default owner of this service is Communicate
-* @mixmaxhq/communicate


### PR DESCRIPTION
## Summary

- Remove the CODEOWNERS file as it is no longer needed